### PR TITLE
en75_dev_xmit: don't free the skb when returning NETDEV_TX_BUSY (use-after-free)

### DIFF
--- a/econet_port.c
+++ b/econet_port.c
@@ -211,6 +211,18 @@ static netdev_tx_t en75_dev_xmit(struct sk_buff *skb, struct net_device *dev)
 
 	if (ret < 0) {
 		netdev_tx_completed_queue(txq, 1, len);
+		if (ret == -EBUSY) {
+			/* The TX ring is full and en75_qdma_xmit() did not consume
+			 * the skb. A NETDEV_TX_BUSY return makes the qdisc layer
+			 * requeue this same skb, so it must stay alive: stop the
+			 * queue and return without freeing. Freeing it here and
+			 * returning NETDEV_TX_BUSY requeues freed memory into
+			 * q->gso_skb -> use-after-free in __qdisc_run() under
+			 * sustained TX.
+			 */
+			netif_tx_stop_queue(txq);
+			return NETDEV_TX_BUSY;
+		}
 		goto error;
 	}
 
@@ -222,11 +234,6 @@ static netdev_tx_t en75_dev_xmit(struct sk_buff *skb, struct net_device *dev)
 error:
 	dev_kfree_skb_any(skb);
 	dev->stats.tx_dropped++;
-
-	if (ret == -EBUSY) {
-		netif_tx_stop_queue(txq);
-		return NETDEV_TX_BUSY;
-	}
 
 	return NETDEV_TX_OK;
 }


### PR DESCRIPTION
## What

`en75_dev_xmit()` frees the skb with `dev_kfree_skb_any()` and then returns
`NETDEV_TX_BUSY` when the QDMA TX ring is full. That's a use-after-free: per the
contract the qdisc layer requeues the skb, so the driver must not free it. The
freed skb is requeued into `q->gso_skb` and the next `__qdisc_run()`
dereferences it → kernel panic under sustained forwarding load.

## The crash (XR500v, EN751221, 6.12.80, ~280 Mbit/s Wi-Fi→LAN)

```
epc == __qdisc_run+0x2f8   ra == __dev_queue_xmit+0x338   Comm: napi/phy1-9   BadVA: 00000004
```

`objdump` of `__qdisc_run+0x2f8` is the inlined `__skb_dequeue(&q->gso_skb)`
unlink (`next->prev = prev` with `next == NULL` → store to offset 0x4).

## Root cause

`en75_qdma_xmit()` returns `-EBUSY` (freelist exhausted,
`index`/`next_index == 0xffff`) **before** consuming or DMA-mapping the skb — so
the skb is intact and still owned by the caller. But `error:` frees it and
returns `NETDEV_TX_BUSY`. `dev_xmit_complete(NETDEV_TX_BUSY)` is false, so
`sch_direct_xmit()` requeues the (freed) skb via `dev_requeue_skb()`.
`Documentation/networking/driver.rst`: *"If you return NETDEV_TX_BUSY … you must
not keep any reference to that SKB and you must not attempt to free it up."*

## Why it's latent / how I reproduce it

With default BQL the queue tunes to ~1 packet in flight, so the 128-entry TX
ring practically never fills and `-EBUSY` is essentially never returned — the
UAF stays dormant. I hit it reliably because I carry a downstream patch that
raises `dql.min_limit` (a BQL floor I use to recover throughput around the
per-packet TX completion), which keeps the ring saturated. You may not reproduce
it without such a floor, but the contract violation is real either way and the
fix is essentially free — the `-EBUSY` skb is provably intact (`en75_qdma_xmit`
bails before `dma_map`), so requeuing it is safe.

## Fix

Handle `-EBUSY` before the error path: `netif_tx_stop_queue()` + return
`NETDEV_TX_BUSY` with the skb intact, letting the stack requeue it. Keep
`error:` for genuine unrecoverable errors only (skb_linearize / dma_mapping
failure) → free + `NETDEV_TX_OK`.

## Tested on device

TP-Link Archer XR500v (EN751221). Before: every sustained 5 GHz speedtest panics
at `__qdisc_run+0x2f8`. After: two sustained speedtests, **0 panics**, **736
requeues** on the `eth0` mq root (the `-EBUSY` path exercised and handled
gracefully), no tx watchdog timeout.
